### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,2 +1,2 @@
-supervisely==6.72.125
+supervisely==6.73.564
 cvat-sdk==2.7.0

--- a/import_cvat/config.json
+++ b/import_cvat/config.json
@@ -10,7 +10,7 @@
   "need_gpu": false,
   "community_agent": true,
   "docker_image": "supervisely/base-py-sdk:6.73.564",
-  "instance_version": "6.6.7",
+  "instance_version": "6.15.60",
   "entrypoint": "python import_cvat/src/main.py",
   "port": 8000,
   "headless": true,

--- a/import_cvat/config.json
+++ b/import_cvat/config.json
@@ -9,7 +9,7 @@
   "categories": ["images", "videos", "import"],
   "need_gpu": false,
   "community_agent": true,
-  "docker_image": "supervisely/base-py-sdk:6.72.125",
+  "docker_image": "supervisely/base-py-sdk:6.73.564",
   "instance_version": "6.6.7",
   "entrypoint": "python import_cvat/src/main.py",
   "port": 8000,

--- a/migration_tool/config.json
+++ b/migration_tool/config.json
@@ -3,7 +3,7 @@
   "version": "2.0.0",
   "name": "CVAT to Supervisely Migration Tool",
   "description": "Convert and copy multiple CVAT projects into Supervisely at once.",
-  "docker_image": "supervisely/base-py-sdk:6.72.125",
+  "docker_image": "supervisely/base-py-sdk:6.73.564",
   "categories": ["images", "videos", "import", "migration"],
   "icon": "https://github.com/supervisely-ecosystem/cvat-to-sly/assets/119248312/ce71514b-72e6-4d1e-947d-90928617c069",
   "icon_cover": true,

--- a/migration_tool/config.json
+++ b/migration_tool/config.json
@@ -1,5 +1,6 @@
 {
   "type": "app",
+  "instance_version": "6.15.60",
   "version": "2.0.0",
   "name": "CVAT to Supervisely Migration Tool",
   "description": "Convert and copy multiple CVAT projects into Supervisely at once.",


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
